### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,5 +1,8 @@
 name: SPECTRE-GIT Security Scanner
 
+permissions:
+  contents: read
+
 on:
   # Run on push to main branch
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GBIGG99/musical-eureka/security/code-scanning/3](https://github.com/GBIGG99/musical-eureka/security/code-scanning/3)

To fix the problem, an explicit `permissions:` block should be added to the workflow, giving only the minimum required permissions for all jobs. In this case, all jobs just read contents and upload artifacts, so `contents: read` is sufficient.

The best way to implement this is to add the following block near the top of the workflow file, at the root level (preferably after the workflow name and before `on:`), like so:
```yaml
permissions:
  contents: read
```
Alternatively, if different jobs needed different permissions, individual `permissions:` blocks could be added under each job. But since all jobs here require only minimal read access, it is most maintainable and secure to add a single block at the top. No further imports or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
